### PR TITLE
BUGFIX: Implement \Stringable in Proxy objects so the Neos node service will work properly

### DIFF
--- a/Classes/ImageAssetProxy.php
+++ b/Classes/ImageAssetProxy.php
@@ -16,7 +16,7 @@ use Neos\Media\Domain\Model\ImageVariant;
  * @phpstan-type assetProxyShape assetProxyShapeV8|assetProxyShapeV9
  */
 #[Flow\Proxy(false)]
-final class ImageAssetProxy implements \JsonSerializable
+final class ImageAssetProxy implements \JsonSerializable, \Stringable
 {
     /**
      * @param class-string $classname
@@ -65,5 +65,10 @@ final class ImageAssetProxy implements \JsonSerializable
           '__flow_object_type' => $this->classname,
           '__identifier' => $this->identifier
         ];
+    }
+
+    public function __toString(): string
+    {
+        return json_encode($this->jsonSerialize(), JSON_THROW_ON_ERROR);
     }
 }

--- a/Classes/ImageSourceProxy.php
+++ b/Classes/ImageSourceProxy.php
@@ -11,7 +11,7 @@ use Neos\Flow\Annotations as Flow;
  * @phpstan-type imagesourceProxyShape array{asset:assetProxyShape, alt?:string, title?: string}
  */
 #[Flow\Proxy(false)]
-final class ImageSourceProxy implements \JsonSerializable
+final class ImageSourceProxy implements \JsonSerializable, \Stringable
 {
     public function __construct(
         public readonly ImageAssetProxy $asset,
@@ -51,6 +51,6 @@ final class ImageSourceProxy implements \JsonSerializable
 
     public function __toString(): string
     {
-        return '-';
+        return json_encode($this->jsonSerialize(), JSON_THROW_ON_ERROR);
     }
 }

--- a/Classes/ImageSourceProxyCollection.php
+++ b/Classes/ImageSourceProxyCollection.php
@@ -12,7 +12,7 @@ use Neos\Flow\Annotations as Flow;
  * @implements \IteratorAggregate<int, ImageSourceProxy>
  */
 #[Flow\Proxy(false)]
-class ImageSourceProxyCollection implements \IteratorAggregate, \Countable, \JsonSerializable
+class ImageSourceProxyCollection implements \IteratorAggregate, \Countable, \JsonSerializable, \Stringable
 {
     /**
      * @var ImageSourceProxy[]
@@ -99,5 +99,10 @@ class ImageSourceProxyCollection implements \IteratorAggregate, \Countable, \Jso
             fn(ImageSourceProxy $item) => $item->jsonSerialize(),
             $this->items,
         );
+    }
+
+    public function __toString(): string
+    {
+        return json_encode($this->jsonSerialize(), JSON_THROW_ON_ERROR);
     }
 }


### PR DESCRIPTION
This will prevent: `Object of class Sitegeist\Kaleidoscope\ValueObjects\ImageSourceProxyCollection could not be converted to string` in the neos node service